### PR TITLE
Header levels

### DIFF
--- a/renderers/header/index.jsx
+++ b/renderers/header/index.jsx
@@ -22,7 +22,9 @@ const HeaderOutput = ({ data, style, classNames, config }) => {
   if (!data) return '';
   if (!style || typeof style !== 'object') style = {};
   if (!config || typeof config !== 'object') config = {};
-  if (!classNames || typeof classNames !== 'string') classNames = '';
+  if (!classNames || (typeof classNames !== 'string' && typeof classNames !== 'object')) classNames = '';
+
+  if(typeof classNames === 'object' && data.level) classNames = classNames[`h${data.level}`];
 
   const headerStyle = config.disableDefaultStyle ? style : { ...headerOutputStyle, ...style };
   let content = null;

--- a/renderers/header/index.jsx
+++ b/renderers/header/index.jsx
@@ -24,7 +24,7 @@ const HeaderOutput = ({ data, style, classNames, config }) => {
   if (!config || typeof config !== 'object') config = {};
   if (!classNames || (typeof classNames !== 'string' && typeof classNames !== 'object')) classNames = '';
 
-  if(typeof classNames === 'object' && data.level) classNames = classNames[`h${data.level}`];
+  if(typeof classNames === 'object' && data.level) classNames = classNames[`h${data.level}`] || '';
 
   const headerStyle = config.disableDefaultStyle ? style : { ...headerOutputStyle, ...style };
   let content = null;


### PR DESCRIPTION
<!--
Thanks for your contribution! 😄

For new features, please send pull request to feature branch.
For everything else, please send pull request to master branch.
Pull request will be merged after one of our collaborators approve.
Please makes sure specify the following before submitting your pull request, thank you!

-->

### 🤔 This is a ...

- [x] New feature
- [ ] Bug fix
- [ ] Site / document update
- [x] Component style update
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (what?)

### 🔗 Related issue link

<!--
1. Describe the source of requirement, like related issue link.
-->

### 💡 Background and solution https://github.com/dev-juju/EditorJS-React-Renderer/issues/46
When using TailwindCSS or other CSS frameworks, header tags (h1, h2, h3) do not have default styles. When I try to define the styles by using the `classNames` prop, with `{ header: 'text-xl '}`, it applies the same class for all the header levels, so they look the same

```
// Original
{
   header: 'text-3xl'
}


// Proposal
header: {
   h1: 'text-3xl',
   h2: 'text-2xl',
   h3: 'text-xl'
}
```

<!--
1. Describe the problem and the scenario.
2. GIF or snapshot should be provided if includes UI/interactive modification.
3. How to fix the problem, and list final API implementation and usage sample if that is a new feature.
-->

### 📝 Changelog

<!--
Describe changes from users perspective, and list all potential breaking changes or other risks.
--->

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Added levels classNames for header component. Also, legacy support is provided (old way works too) |

### ☑️ Self Check before Merge

- [ ] Doc is updated/provided or not needed
- [ ] Demo/Example is updated/provided or not needed
- [ ] Changelog is provided or not needed
